### PR TITLE
Add icons for aspect ratio options

### DIFF
--- a/source/icons/AspectRatio11.svg
+++ b/source/icons/AspectRatio11.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_694_983)">
+<rect x="21" y="3" width="18" height="18" rx="0.3" transform="rotate(89.2654 21 3)" stroke="#344054"/>
+</g>
+<defs>
+<clipPath id="clip0_694_983">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/source/icons/AspectRatio169.svg
+++ b/source/icons/AspectRatio169.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_694_986)">
+<rect x="21.9222" y="6" width="12" height="20" rx="0.3" transform="rotate(89.2654 21.9222 6)" stroke="#344054"/>
+</g>
+<defs>
+<clipPath id="clip0_694_986">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/source/icons/AspectRatio32.svg
+++ b/source/icons/AspectRatio32.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_694_984)">
+<rect x="18" y="3" width="18" height="13.5" rx="0.3" transform="rotate(89.2654 18 3)" stroke="#344054"/>
+</g>
+<defs>
+<clipPath id="clip0_694_984">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/source/icons/AspectRatio43.svg
+++ b/source/icons/AspectRatio43.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_694_985)">
+<rect x="18" y="4" width="16" height="12" rx="0.3" transform="rotate(89.2654 18 4)" stroke="#344054"/>
+</g>
+<defs>
+<clipPath id="clip0_694_985">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/source/icons/AspectRatio916.svg
+++ b/source/icons/AspectRatio916.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_694_987)">
+<rect x="6" y="2" width="12" height="20" rx="0.3" stroke="#344054"/>
+</g>
+<defs>
+<clipPath id="clip0_694_987">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
- Fixes #500

<img width="878" height="165" alt="Screenshot 2025-12-10 at 3 24 11 PM" src="https://github.com/user-attachments/assets/dfb45bb5-c32c-40bd-87d7-dd2161a917b7" />

@praveen-murali-ind _a

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
