### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # neetoIcons
 
-The neetoIcons and neetoIconsRN library are a collection of SVG React component
-icons that drives the experience in the neeto products built at BigBinary.
+The neetoIcons and neetoIconsRN library are a collection of SVG React component icons that drives
+the experience in the neeto products built at BigBinary.
 
 ## Contents
 
@@ -26,14 +26,12 @@ yarn add @bigbinary/neeto-icons-rn
 
 ### Instructions for development
 
-Check the [Frontend package development
-guide](https://neeto-engineering.neetokb.com/p/a-d34cb4b0) for step-by-step
-instructions to develop the frontend package.
+Check the [Frontend package development guide](https://neeto-engineering.neetokb.com/p/a-d34cb4b0) for step-by-step instructions to develop the frontend package.
 
 #### Adding a new icon to the library
 
-1. **Add the SVG file -** Place the SVG file for the new icon in the appropriate
-   folder under the `source` directory. For example:
+1. **Add the SVG file -**
+   Place the SVG file for the new icon in the appropriate folder under the `source` directory. For example:
    - `icons/` for normal icons
    - `logos/` for product logos
    - `typefaceLogos/` for product typeface logos
@@ -41,11 +39,11 @@ instructions to develop the frontend package.
    - `misc/` for miscellaneous icons
    - `elements/` for elements
 
-2. **Name the file appropriately -** Use PascalCase for the file name (e.g.,
-   `NewIcon.svg`).
+2. **Name the file appropriately -**
+   Use PascalCase for the file name (e.g., `NewIcon.svg`).
 
-3. **Verify the icon -** Run the `yarn start` command to verify the React
-   component for the new icon:
+3. **Verify the icon -**
+   Run the `yarn start` command to verify the React component for the new icon:
 
 ### Usage
 
@@ -172,6 +170,4 @@ Anywhere in your React file
 
 ## Instructions for Publishing
 
-Consult the [building and releasing
-packages](https://neeto-engineering.neetokb.com/articles/building-and-releasing-packages)
-guide for details on how to publish.
+Consult the [building and releasing packages](https://neeto-engineering.neetokb.com/articles/building-and-releasing-packages) guide for details on how to publish.


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
